### PR TITLE
CSCwe91656 - 'LTS' version of ubuntu name not picked up properly

### DIFF
--- a/os-discovery-tool/debian-os-name.sh
+++ b/os-discovery-tool/debian-os-name.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cat /etc/*-release | grep VERSION | head -n1 | awk -F"=" '{print $2}' | xargs | awk '{print "Ubuntu "$1" "$2}'
+cat /etc/*-release | grep 'VERSION\=' | head -n1 | awk -F"=" '{print $2}' | xargs | awk '{print "Ubuntu "$1" "$2}'

--- a/os-discovery-tool/debian-os-version.sh
+++ b/os-discovery-tool/debian-os-version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cat /etc/*-release | grep VERSION | head -n1 | awk -F"=" '{print $2}' | xargs | \
+cat /etc/*-release | grep 'VERSION\=' | head -n1 | awk -F"=" '{print $2}' | xargs | \
 awk '{print "Ubuntu Server "$1" "$2}'; 


### PR DESCRIPTION
VERSION and VERSION_ID fields in the os-release files changed its order in the latest version of ubuntu which caused the issue.

in ubuntu 20.04.3 version:
VERSION="20.04.3 LTS (Focal Fossa)"
VERSION_ID="20.04"

in ubuntu 22.04.1 version:
VERSION_ID="22.04"
VERSION="22.04.1 LTS (Jammy Jellyfish)"

sample output:
ubuntu 20.04.3 version: Ubuntu Server 20.04.3 LTS
ubuntu 22.04.1 version: Ubuntu Server 22.04.1 LTS