### PR TITLE
CSCwe91663 - hcl software compliance failed for oracle OS due to wrong version populated.

### DIFF
--- a/os-discovery-tool/get_linux_inv_to_intersight.py
+++ b/os-discovery-tool/get_linux_inv_to_intersight.py
@@ -65,7 +65,7 @@ class OsType:
     SUSE = ["Suse", "Sles"]
     DEBIAN = ["Ubuntu"]
     REDHAT = ["Red Hat", "Rhel", "Centos", "Rocky"]
-    ORACLE = ["Ol"]
+    ORACLE = ["ol"]
 
 
 class ValidationResult(Enum):
@@ -348,7 +348,7 @@ class OsInvReader(InvReader):
                     ExecType.SCRIPT,
                     QueryType.OS,
                     "suse-os-version.sh"))
-        elif os_vendor in OsType.ORACLE:
+        elif os_vendor.lower() in OsType.ORACLE:
             self.os_type = OsType.ORACLE
             os_flavor = (
                 self.invoke_shell(
@@ -396,8 +396,8 @@ class OsInvReader(InvReader):
             os_vendor = "CentOS"
         elif os_vendor == "Sles":
             os_vendor = "SuSE"
-        elif os_vendor == "Ol":
-            os_vendor = "Oracle Linux"
+        elif os_vendor.lower() == "ol":
+            os_vendor = "Oracle"
         elif os_vendor == "Rocky":
             os_vendor = "Rocky Linux"
             os_flavor = os_name

--- a/os-discovery-tool/oracle-os-version.sh
+++ b/os-discovery-tool/oracle-os-version.sh
@@ -5,7 +5,7 @@ oracle_version=$(cat /etc/*-release | grep ^VERSION | head -n1 | awk -F"=" '{pri
 
 if [[ $kernel == *"uek"* ]];
   then
-  echo $oracle_version "(UEK "$version")"
+  echo "Oracle Linux (UEK v"$version")"
 else
   echo $oracle_version
 fi

--- a/os-discovery-tool/oracle-os-version.sh
+++ b/os-discovery-tool/oracle-os-version.sh
@@ -5,7 +5,7 @@ oracle_version=$(cat /etc/*-release | grep ^VERSION | head -n1 | awk -F"=" '{pri
 
 if [[ $kernel == *"uek"* ]];
   then
-  echo "Oracle Linux (UEK v"$version")"
+  echo "Oracle Linux (UEK "$version")"
 else
   echo $oracle_version
 fi


### PR DESCRIPTION
Version format expected is : Oracle Linux (UEK 5.15.0-0.x), earlier the format was 9.0 (UEK 5.15.0-0.x) and hence it was failing.
