### PR TITLE
CSCwe98725 - To get os name and version from /etc/rocky-release file

### DIFF
--- a/os-discovery-tool/rocky-os-name.sh
+++ b/os-discovery-tool/rocky-os-name.sh
@@ -1,2 +1,8 @@
 #!/bin/bash
-cat /etc/centos-release 2>/dev/null | awk '{print $1" "$2" "$4}' | xargs
+FILE=/etc/rocky-release
+if [ -f "$FILE" ]; then
+    # from Rocky Linux 9.1 file name changed to rocky-release
+    cat $FILE 2>/dev/null | awk '{print $1" "$2" "$4}' | xargs
+else
+    cat /etc/centos-release 2>/dev/null | awk '{print $1" "$2" "$4}' | xargs
+fi


### PR DESCRIPTION
Rocky linux is a fork of centos, so earlier versions had /etc/centos-release file from which we get the os version, from 9.1 version the file name has changed to /etc/rocky-release and it is handled as part of this commit.