### PR TITLE
CSCwe91663: storage name contains quotes which causes xargs to throw exception

### DIFF
--- a/os-discovery-tool/storagedev.sh
+++ b/os-discovery-tool/storagedev.sh
@@ -4,5 +4,5 @@ lshwcmd=`which lshw`
 lspcicmd=`which lspci`
 for pciaddress in $(${lshwcmd} -C Storage 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    ${lspcicmd} -v -s ${pciaddress} | grep "Subsystem" | awk -F":" '{print $2}'| xargs;
+    ${lspcicmd} -v -s ${pciaddress} | grep "Subsystem" | awk -F":" '{print $2}';
 done


### PR DESCRIPTION
storage name: Cisco Systems Inc NVMe Datacenter SSD [3DNAND] 3.2TB 2.5" U.2 (P4600)
**Issue:**
/usr/sbin/lspci -v -s b0:00.0 | grep "Subsystem" | awk -F":" '{print $2}'| xargs
xargs: unmatched double quote; by default quotes are special to xargs unless you use the -0 option
Cisco Systems Inc NVMe Datacenter SSD [3DNAND] 3.2TB
Storage name not fetched fully since the name contains double quotes and double quotes are special to xargs. the exit code returned is 1.

**solution**
there is no need for xargs here as we are not passing any arguments to any command, it is just defaulted to echo in this case. so removing this to solve the issue.
/usr/sbin/lspci -v -s b0:00.0 | grep "Subsystem" | awk -F":" '{print $2}'
 Cisco Systems Inc NVMe Datacenter SSD [3DNAND] 3.2TB 2.5" U.2 (P4600)
 Now name is fetched fully and the exit code is 0.
 
 **NOTE:** Storage name did not contain any special character like double quotes earlier (for e.g: Cisco Systems Inc Device 02c6) and it worked fine, but now we are getting storage names with double quotes which causing issues.


