### PR TITLE
CSCwd92285: Ubuntu 22.04 does not contain LTS in version

### DIFF
--- a/os-discovery-tool/debian-os-name.sh
+++ b/os-discovery-tool/debian-os-name.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cat /etc/*-release | grep 'VERSION\=' | head -n1 | awk -F"=" '{print $2}' | xargs | awk '{print "Ubuntu "$1" "$2}'
+cat /etc/*-release | grep 'PRETTY_NAME\=' | head -n1 | awk -F"=" '{print $2}' | xargs | awk '{print $1" "$2" "$3}'

--- a/os-discovery-tool/debian-os-version.sh
+++ b/os-discovery-tool/debian-os-version.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cat /etc/*-release | grep 'VERSION\=' | head -n1 | awk -F"=" '{print $2}' | xargs | \
-awk '{print "Ubuntu Server "$1" "$2}'; 
+cat /etc/*-release | grep 'PRETTY_NAME\=' | head -n1 | awk -F'=' '{print $2}' | awk -F'"' '{print $2}' | awk -F" " '{print $1" Server "$2" "$3}'


### PR DESCRIPTION
**Root cause:**
In the /etc/os-release file of ubuntu, string "LTS" is missing in some of the version.

For e.g:
In ubuntu 22.04.1 LTS (valid one):
PRETTY_NAME="Ubuntu 22.04.1 LTS"
VERSION="22.04.1 LTS (Jammy Jellyfish)"

In ubuntu 22.04 LTS (defect):
PRETTY_NAME="Ubuntu 22.04 LTS"
VERSION="22.04 (Jammy Jellyfish)"

VERSION is missing "LTS" in 22.04 which causing the issue.

and the version string is optional as per ubuntu documentation, refer: https://manpages.ubuntu.com/manpages/lunar/man5/os-release.5.html

**Fix:** Getting version details from PRETTY_NAME field.
**Output:**
Ubuntu 22.04 LTS
Ubuntu 22.04.1 LTS

in both the cases it worked fine.
