### PR TITLE
CSCwi95330: hwinfo cmd no longer returning version info, instead get the version from vermagic key

### DIFF
--- a/os-discovery-tool/suse-netversions.sh
+++ b/os-discovery-tool/suse-netversions.sh
@@ -2,10 +2,13 @@
 export PATH=$PATH:/sbin:/usr/sbin
 hwinfocmd=`which hwinfo`
 modinfocmd=`which modinfo`
-versionstring=`${hwinfocmd} --network | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep ^version:`
-if [ -z "$versionstring" ]
-then
-    ${hwinfocmd} --network | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep ^vermagic: | awk '{print $2}'
-else
-    ${versionstring} | awk -F":[[:space:]]+" '{print $2}'
-fi
+drivers=`${hwinfocmd} --network | grep Driver: | awk '{gsub(/"/,"",$2); print $2}'`
+for driver in $drivers; do
+    versionstring=`$modinfocmd $driver | grep ^version:`
+    if [ -z "$versionstring" ]
+    then
+        $modinfocmd $driver | grep ^vermagic: | awk '{print $2}'
+    else
+        $modinfocmd $driver | grep ^version: | awk -F":[[:space:]]+" '{print $2}'
+    fi
+done

--- a/os-discovery-tool/suse-netversions.sh
+++ b/os-discovery-tool/suse-netversions.sh
@@ -3,12 +3,12 @@ export PATH=$PATH:/sbin:/usr/sbin
 hwinfocmd=`which hwinfo`
 modinfocmd=`which modinfo`
 drivers=`${hwinfocmd} --network | grep Driver: | awk '{gsub(/"/,"",$2); print $2}'`
-for driver in $drivers; do
-    versionstring=`$modinfocmd $driver | grep ^version:`
-    if [ -z "$versionstring" ]
+for driver in ${drivers}; do
+    versionstring=`${modinfocmd} ${driver} | grep ^version:`
+    if [ -z "${versionstring}" ]
     then
-        $modinfocmd $driver | grep ^vermagic: | awk '{print $2}'
+        ${modinfocmd} ${driver} | grep ^vermagic: | awk '{print $2}'
     else
-        $modinfocmd $driver | grep ^version: | awk -F":[[:space:]]+" '{print $2}'
+        ${modinfocmd} ${driver} | grep ^version: | awk -F":[[:space:]]+" '{print $2}'
     fi
 done

--- a/os-discovery-tool/suse-netversions.sh
+++ b/os-discovery-tool/suse-netversions.sh
@@ -2,5 +2,10 @@
 export PATH=$PATH:/sbin:/usr/sbin
 hwinfocmd=`which hwinfo`
 modinfocmd=`which modinfo`
-${hwinfocmd} --network | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | \
-	grep ^version: | awk -F":[[:space:]]+" '{print $2}'
+isversionfound=`${hwinfocmd} --network | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep ^version:`
+if [ -z "$isversionfound" ]
+then
+    ${hwinfocmd} --network | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep ^vermagic: | awk '{print $2}'
+else
+    ${isversionfound} | awk -F":[[:space:]]+" '{print $2}'
+fi

--- a/os-discovery-tool/suse-netversions.sh
+++ b/os-discovery-tool/suse-netversions.sh
@@ -2,10 +2,10 @@
 export PATH=$PATH:/sbin:/usr/sbin
 hwinfocmd=`which hwinfo`
 modinfocmd=`which modinfo`
-isversionfound=`${hwinfocmd} --network | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep ^version:`
-if [ -z "$isversionfound" ]
+versionstring=`${hwinfocmd} --network | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep ^version:`
+if [ -z "$versionstring" ]
 then
     ${hwinfocmd} --network | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep ^vermagic: | awk '{print $2}'
 else
-    ${isversionfound} | awk -F":[[:space:]]+" '{print $2}'
+    ${versionstring} | awk -F":[[:space:]]+" '{print $2}'
 fi


### PR DESCRIPTION
The following command output does not contains the 'version' information:
`hwinfo --network | grep Driver: | awk '{print $2}' | xargs modinfo`
instead the output contains only the following:
```
srcversion:     6E2C63290F9B5E5ABDCD025
vermagic:       5.14.21-150500.53-default SMP preempt mod_unload modversions 
```
from which we are filtering vermagic version information.