### PR TITLE
CSCwi97567: To fetch proper enic version

### DIFF
--- a/os-discovery-tool/netversions.sh
+++ b/os-discovery-tool/netversions.sh
@@ -6,13 +6,12 @@ modinfocmd=`which modinfo`
 for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
     versionstring=`${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | \
-    awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version:`
-    if [ -z "${versionstring}" ]
+    awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | head -n1 | awk '{print $2}' | xargs`
+if [ -z "${versionstring}" ]
     then
-        ${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}' | \
-    xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'
+        echo `${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}' | \
+    xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'`
     else
-        ${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}' | \
-    xargs ${modinfocmd} 2>/dev/null | grep -i "version" | head -n1 | awk '{print $2}' | xargs;
+        echo ${versionstring}
     fi
 done

--- a/os-discovery-tool/netversions.sh
+++ b/os-discovery-tool/netversions.sh
@@ -5,7 +5,14 @@ lspcicmd=`which lspci`
 modinfocmd=`which modinfo`
 for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    ${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | \
-    awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep -i "version" | \
-    head -n1 | awk '{print $2}' | xargs;
+    versionstring=`${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | \
+    awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version:`
+    if [ -z "${versionstring}" ]
+    then
+        ${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}' | \
+    xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'
+    else
+        ${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}' | \
+    xargs ${modinfocmd} 2>/dev/null | grep -i "version" | head -n1 | awk '{print $2}' | xargs;
+    fi
 done


### PR DESCRIPTION
Used 'vermagic' value as driver version if 'version' key not found in the output.

E.g output: 
[root@localhost ~]# ./netversions.sh 
5.15.0-0.30.19.el9uek.x86_64