### PR TITLE
ISPLAT-13588: RedHat CoreOS POC - Initial commit

### DIFF
--- a/os-discovery-tool/Dockerfile
+++ b/os-discovery-tool/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu
+SHELL ["/bin/bash", "-c"]
+
+# Install necessary packages
+RUN apt-get update && \
+    apt-get update --fix-missing && \
+    apt-get install -y lshw kmod hwinfo pciutils && \
+    apt-get clean
+
+# Create a volume for the code
+VOLUME /app
+
+# Copy the HCL Scripts to collect driver information
+COPY ./netdriver.sh /app/
+COPY ./rchosdockernetversions.sh /app/
+COPY ./netdev.sh /app/
+COPY ./storagedriver.sh /app/
+COPY ./storagedev.sh /app/
+COPY ./storagedevnames.sh /app/
+
+# Set the working directory
+WORKDIR /app

--- a/os-discovery-tool/get_linux_inv_to_intersight.py
+++ b/os-discovery-tool/get_linux_inv_to_intersight.py
@@ -64,7 +64,7 @@ class OsType:
     """This class broadly identifies OS categories."""
     SUSE = ["Suse", "Sles"]
     DEBIAN = ["Ubuntu"]
-    REDHAT = ["Red Hat", "Rhel", "Centos", "Rocky"]
+    REDHAT = ["Red Hat", "Rhel", "Centos", "Rocky", "Rhcos"]
     ORACLE = ["ol"]
 
 
@@ -372,6 +372,9 @@ class OsInvReader(InvReader):
             elif os_vendor == "Rocky":
                 os_name = self.invoke_shell(
                     ExecType.SCRIPT, QueryType.OS, "rocky-os-name.sh")
+            elif os_vendor == "Rhcos":
+                os_name = self.invoke_shell(
+                    ExecType.SCRIPT, QueryType.OS, "rhcos-os-name.sh")
             else:
                 os_name = self.invoke_shell(
                     ExecType.SCRIPT, QueryType.OS, "redhat-os-name.sh")
@@ -389,8 +392,9 @@ class OsInvReader(InvReader):
                 ExecType.SCRIPT,
                 QueryType.OS,
                 "centos-os-name-legacy.sh")
+        self.os_name = os_name
 
-        if os_vendor == "Rhel":
+        if os_vendor in ["Rhel", "Rhcos"]:
             os_vendor = "Red Hat"
         elif os_vendor == "Centos":
             os_vendor = "CentOS"
@@ -423,6 +427,15 @@ class DriverInvReader(InvReader):
         self.os_type = os_type
         self.host_type = host_type
         self.os_collection = os_collection
+
+    def get_storage_driver_args(self, storageNames):
+        names = []
+        output = ''
+        for name in storageNames:
+            if name and name not in names:
+                names.append(name)
+                output += '"{0} "'.format(name)
+        return output
 
     def get_driver_inv(self):
         """Collect device and driver data."""
@@ -467,6 +480,15 @@ class DriverInvReader(InvReader):
                                           QueryType.DRIVER, "suse-storageversions.sh")
             descriptions += self.invoke_shell(ExecType.SCRIPT,
                                               QueryType.DRIVER, "suse-storagedev.sh")
+        elif self.os_type == OsType.REDHAT and "coreos" in os_name.lower():
+            drivers = self.invoke_shell(ExecType.SCRIPT, QueryType.DRIVER, "rchosnetdriver.sh")
+            versions = self.invoke_shell(ExecType.SCRIPT, QueryType.DRIVER, "rchosnetversions.sh")
+            descriptions = self.invoke_shell(ExecType.SCRIPT, QueryType.DRIVER, "rchosnetdev.sh")
+            drivers += self.invoke_shell(ExecType.SCRIPT, QueryType.DRIVER, "rchosstoragedriver.sh")
+            descriptions += self.invoke_shell(ExecType.SCRIPT, QueryType.DRIVER, "rchosstoragedev.sh")
+            storagenames = self.invoke_shell(ExecType.SCRIPT, QueryType.DRIVER, "rchosstoragedevnames.sh")
+            storagenameasargs = self.get_storage_driver_args(storagenames)
+            versions += self.invoke_shell(ExecType.SCRIPT, QueryType.DRIVER, "rchosstoragedevversion.sh " + storagenameasargs)
         else:
             drivers = self.invoke_shell(
                 ExecType.SCRIPT, QueryType.DRIVER, "netdriver.sh")

--- a/os-discovery-tool/rchos-os-name.sh
+++ b/os-discovery-tool/rchos-os-name.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cat /etc/redhat-release | awk '{print $1" "$2" "$3" "$4" "$5" "$7}'

--- a/os-discovery-tool/rchosdockernetversions.sh
+++ b/os-discovery-tool/rchosdockernetversions.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+export PATH=$PATH:/sbin:/usr/sbin
+lshwcmd=`which lshw`
+lspcicmd=`which lspci`
+modinfocmd=`which modinfo`
+enicdrivername="enic"
+for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
+    do
+        drivername=`${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}'`
+        if [[ $drivername == *"$enicdrivername"* ]]
+        then
+            kernalversion=`uname -r`
+            echo ${kernalversion%.*}
+        else
+            versionstring=`${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | \
+            awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | head -n1 | awk '{print $2}' | xargs`
+            if [ -z "${versionstring}" ]
+            then
+                echo `${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}' | \
+                xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'`
+            else
+                echo ${versionstring}
+            fi
+        fi
+    done

--- a/os-discovery-tool/rchosnetdev.sh
+++ b/os-discovery-tool/rchosnetdev.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+podman run --rm --privileged hcltools:v1 /app/netdev.sh

--- a/os-discovery-tool/rchosnetdriver.sh
+++ b/os-discovery-tool/rchosnetdriver.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+podman run --rm --privileged hcltools:v1 /app/netdriver.sh

--- a/os-discovery-tool/rchosnetversions.sh
+++ b/os-discovery-tool/rchosnetversions.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+podman run --rm --privileged hcltools:v1 /app/rchosdockernetversions.sh

--- a/os-discovery-tool/rchosstoragedev.sh
+++ b/os-discovery-tool/rchosstoragedev.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+podman run --rm --privileged hcltools:v1 /app/storagedev.sh

--- a/os-discovery-tool/rchosstoragedevnames.sh
+++ b/os-discovery-tool/rchosstoragedevnames.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+podman run --rm --privileged hcltools:v1 /app/storagedevnames.sh

--- a/os-discovery-tool/rchosstoragedevversion.sh
+++ b/os-discovery-tool/rchosstoragedevversion.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export PATH=$PATH:/sbin:/usr/sbin
+modinfocmd=`which modinfo`
+for var in "$@"
+do
+    ${modinfocmd} ${var} 2>/dev/null| grep -i "version" | head -n1 | awk '{print $2}'
+done

--- a/os-discovery-tool/rchosstoragedriver.sh
+++ b/os-discovery-tool/rchosstoragedriver.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+podman run --rm --privileged hcltools:v1 /app/storagedriver.sh

--- a/os-discovery-tool/storagedevnames.sh
+++ b/os-discovery-tool/storagedevnames.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export PATH=$PATH:/sbin:/usr/sbin
+lshwcmd=`which lshw`
+lspcicmd=`which lspci`
+modinfocmd=`which modinfo`
+for pciaddress in $(${lshwcmd} -C Storage 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
+do
+    ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs;
+done


### PR DESCRIPTION
RedHat CoreOS support on OS Discovery Tool
Details:
1. RedHat CoreOs is a read only OS and no software utilities can be installed.
2. Created custom container with all the utilities and run in privileged mode to collect OS and driver related details.