### PR TITLE
INTERSIGHT-33113: use name field for nvme when description not available

### DIFF
--- a/os-discovery-tool/suse-storagedev.sh
+++ b/os-discovery-tool/suse-storagedev.sh
@@ -2,4 +2,4 @@
 export PATH=$PATH:/sbin:/usr/sbin
 hwinfocmd=`which hwinfo`
 modinfocmd=`which modinfo`
-${hwinfocmd} --storage | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep ^description: | awk -F":[[:space:]]+" '{print $2}'
+${hwinfocmd} --storage | grep Driver: | awk '{print $2}' | xargs ${modinfocmd} | grep -E '(^description:|^name:)'  | awk -F":[[:space:]]+" '{print $2}'


### PR DESCRIPTION
Description is an optional field in modinfo output.
When we fetch driver information for nvme, the result does not contain description field and hence using name field whenever description is not available.