### PR TITLE
CSCwn58066: driver version starts with 0 is getting stripped

### DIFF
--- a/os-discovery-tool/get_linux_inv_to_intersight.py
+++ b/os-discovery-tool/get_linux_inv_to_intersight.py
@@ -537,7 +537,7 @@ class DriverInvReader(InvReader):
                 "driver." +
                 str(driver_count) +
                 ".version",
-                versions[i].lstrip("0"))
+                versions[i])
             self.add_item(
                 QueryType.DRIVER,
                 "driver." +


### PR DESCRIPTION
**Driver version before fix:**
```
{
        "Key": "intersight.server.os.driver.0.version",
        "Value": ".8.2-k"
}
```

**Driver version after fix:**
```
{
        "Key": "intersight.server.os.driver.0.version",
        "Value": "0.8.2-k"
}
```