### PR TITLE
CSCwn96365: Added support for Emulex 31002 HBA in Linux ODT

### DIFF
--- a/os-discovery-tool/netdev.sh
+++ b/os-discovery-tool/netdev.sh
@@ -6,4 +6,8 @@ for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" 
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Subsystem" | awk -F":" '{print $2}'| xargs;
 done
-
+# support for Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+do
+    ${lspcicmd} -v -s ${pciaddress} | grep "Subsystem" | awk -F":" '{print $2}'| xargs;
+done

--- a/os-discovery-tool/netdriver.sh
+++ b/os-discovery-tool/netdriver.sh
@@ -6,3 +6,8 @@ for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" 
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs;
 done
+# support for Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+do
+    ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}'| xargs;
+done

--- a/os-discovery-tool/netversions.sh
+++ b/os-discovery-tool/netversions.sh
@@ -15,3 +15,15 @@ if [ -z "${versionstring}" ]
         echo ${versionstring}
     fi
 done
+# support for Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+do
+    hbaversionstring=`${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | awk '{print $2}'`
+    if [ -z "${hbaversionstring}" ]
+    then
+        echo `${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}'| \
+    xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'`
+    else
+        echo ${hbaversionstring}
+    fi
+done


### PR DESCRIPTION
Added support for Emulex 31002 HBA in Linux ODT

Example output:
```
    {
      "Key": "intersight.server.os.driver.2.description",
      "Value": "Emulex Corporation LPe31002-M6 2-Port 16Gb Fibre Channel Adapter"
    },
    {
      "Key": "intersight.server.os.driver.2.name",
      "Value": "lpfc"
    },
    {
      "Key": "intersight.server.os.driver.2.version",
      "Value": "0:14.4.317.2"
    }
```