### PR TITLE
Unable to obtain storage driver name due to key name change

### DIFF
--- a/os-discovery-tool/storagedriver.sh
+++ b/os-discovery-tool/storagedriver.sh
@@ -4,5 +4,5 @@ lshwcmd=`which lshw`
 lspcicmd=`which lspci`
 for pciaddress in $(${lshwcmd} -C Storage 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs;
+    ${lspcicmd} -v -s ${pciaddress} | grep -E 'Kernel (driver|modules)' | awk -F":" '{print $2}' | xargs;
 done

--- a/os-discovery-tool/storageversions.sh
+++ b/os-discovery-tool/storageversions.sh
@@ -5,6 +5,6 @@ lspcicmd=`which lspci`
 modinfocmd=`which modinfo`
 for pciaddress in $(${lshwcmd} -C Storage 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | \
+    ${lspcicmd} -v -s ${pciaddress} | grep -E 'Kernel (driver|modules)' | awk -F":" '{print $2}' | \
     xargs ${modinfocmd} 2>/dev/null| grep -i "version" | head -n1 | awk '{print $2}' | xargs;
 done


### PR DESCRIPTION
Root cause: Key name changed from "Kernal driver" to "Kernal modules" which caused the issue.

example output from server:
```
[root@rhel94 os-discovery-tool]# lspci -v -s 21:00.0
21:00.0 RAID bus controller: Broadcom / LSI MegaRAID 12GSAS/PCIe Secure SAS39xx
	Subsystem: Cisco Systems Inc Device 02bd
	Flags: bus master, fast devsel, latency 0, IRQ 255, NUMA node 0, IOMMU group 44
	Memory at 500b0000000 (64-bit, prefetchable) [size=1M]
	Memory at 500aff00000 (64-bit, prefetchable) [size=1M]
	Memory at b4600000 (32-bit, non-prefetchable) [size=1M]
	I/O ports at 2000 [size=256]
	Expansion ROM at b4500000 [disabled] [size=1M]
	Capabilities: [40] Power Management version 3
	Capabilities: [50] MSI: Enable- Count=1/1 Maskable+ 64bit+
	Capabilities: [70] Express Endpoint, MSI 00
	Capabilities: [b0] MSI-X: Enable- Count=128 Masked-
	Capabilities: [100] Advanced Error Reporting
	Capabilities: [148] Power Budgeting <?>
	Capabilities: [158] Alternative Routing-ID Interpretation (ARI)
	Capabilities: [168] Secondary PCI Express
	Capabilities: [188] Physical Layer 16.0 GT/s <?>
	Capabilities: [1b0] Lane Margining at the Receiver <?>
	Capabilities: [248] Vendor Specific Information: ID=0002 Rev=4 Len=100 <?>
	Capabilities: [348] Vendor Specific Information: ID=0001 Rev=1 Len=038 <?>
	Capabilities: [380] Data Link Feature <?>
	Kernel modules: megaraid_sas
```
issue addressed and the driver name and version getting populated correctly.