### PR TITLE
storage driver name - handled the case when kernel_driver and kernel_modules are present

### DIFF
--- a/os-discovery-tool/storagedriver.sh
+++ b/os-discovery-tool/storagedriver.sh
@@ -4,5 +4,12 @@ lshwcmd=`which lshw`
 lspcicmd=`which lspci`
 for pciaddress in $(${lshwcmd} -C Storage 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    ${lspcicmd} -v -s ${pciaddress} | grep -E 'Kernel (driver|modules)' | awk -F":" '{print $2}' | xargs;
+    pcioutput=$("$lspcicmd" -v -s "$pciaddress")
+    kernel_driver=$(echo "$pcioutput" | grep "Kernel driver" | awk '{print $NF}')
+    kernel_modules=$(echo "$pcioutput" | grep "Kernel modules" | awk '{print $NF}')
+    if [ -n "$kernel_driver" ]; then
+	    echo $kernel_driver
+    else
+	    echo $kernel_modules
+    fi
 done


### PR DESCRIPTION
output is getting duplicated when both the keys are present, so the logic is changed in such a way that - check for the existance of kernel_driver and if not present check for kernel_modules.

Example output from server:
```
[root@rhel94 ~]# lspci -v -s 21:00.0
21:00.0 RAID bus controller: Broadcom / LSI MegaRAID 12GSAS/PCIe Secure SAS39xx
	Subsystem: Cisco Systems Inc Device 02bd
	Flags: bus master, fast devsel, latency 0, IRQ 109, NUMA node 0, IOMMU group 45
	Memory at 500b0000000 (64-bit, prefetchable) [size=1M]
	Memory at 500aff00000 (64-bit, prefetchable) [size=1M]
	Memory at b4600000 (32-bit, non-prefetchable) [size=1M]
	I/O ports at 2000 [size=256]
	Expansion ROM at b4500000 [disabled] [size=1M]
	Capabilities: [40] Power Management version 3
	Capabilities: [50] MSI: Enable- Count=1/1 Maskable+ 64bit+
	Capabilities: [70] Express Endpoint, MSI 00
	Capabilities: [b0] MSI-X: Enable+ Count=128 Masked-
	Capabilities: [100] Advanced Error Reporting
	Capabilities: [148] Power Budgeting <?>
	Capabilities: [158] Alternative Routing-ID Interpretation (ARI)
	Capabilities: [168] Secondary PCI Express
	Capabilities: [188] Physical Layer 16.0 GT/s <?>
	Capabilities: [1b0] Lane Margining at the Receiver <?>
	Capabilities: [248] Vendor Specific Information: ID=0002 Rev=4 Len=100 <?>
	Capabilities: [348] Vendor Specific Information: ID=0001 Rev=1 Len=038 <?>
	Capabilities: [380] Data Link Feature <?>
	Kernel driver in use: megaraid_sas
	Kernel modules: megaraid_sas
```
