### PR TITLE
ODT not fetching QLogic adapter details

### DIFF
--- a/os-discovery-tool/netdev.sh
+++ b/os-discovery-tool/netdev.sh
@@ -6,8 +6,8 @@ for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" 
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Subsystem" | awk -F":" '{print $2}'| xargs;
 done
-# support for Emulex HBA Adapter
-${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+# support for QLogic and Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel|Fibre Channel' | awk -F" " '{print $1}' | while read pciaddress;
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Subsystem" | awk -F":" '{print $2}'| xargs;
 done

--- a/os-discovery-tool/netdriver.sh
+++ b/os-discovery-tool/netdriver.sh
@@ -6,8 +6,8 @@ for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" 
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs;
 done
-# support for Emulex HBA Adapter
-${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+# support for QLogic and Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel|Fibre Channel' | awk -F" " '{print $1}' | while read pciaddress;
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}'| xargs;
 done

--- a/os-discovery-tool/netversions.sh
+++ b/os-discovery-tool/netversions.sh
@@ -15,8 +15,8 @@ if [ -z "${versionstring}" ]
         echo ${versionstring}
     fi
 done
-# support for Emulex HBA Adapter
-${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+# support for QLogic and Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel|Fibre Channel' | awk -F" " '{print $1}' | while read pciaddress;
 do
     hbaversionstring=`${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | awk '{print $2}'`
     if [ -z "${hbaversionstring}" ]


### PR DESCRIPTION
Output from server:
```
[root@rhel88 os-discovery-tool]# lspci -nn | grep -Ei 'Fibre Channel'
19:00.0 Fibre Channel [0c04]: QLogic Corp. ISP2722-based 16/32Gb Fibre Channel to PCIe Adapter [1077:2261] (rev 01)
```
to find QLogic adapter details, we have to filter 'Fibre Channel' in title case, earlier code contins only lowercase which does not picked it up.