### PR TITLE
use rocm driver version for amdgpu

### DIFF
--- a/os-discovery-tool/gpudev.sh
+++ b/os-discovery-tool/gpudev.sh
@@ -5,7 +5,7 @@ lspcicmd=`which lspci`
 gpuvendornvidia='nvidia'
 gpuvendoramd='amd'
 nvidiasmicmd=`which nvidia-smi 2>&1`
-amdsmicmd=`which amd-smi 2>&1`
+amdcmdpath="/opt/rocm/.info/version"
 invalid=" |'"
 
 for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
@@ -18,7 +18,7 @@ do
         fi
     # AMD Vendor GPU
     elif [[ ${displaydevice,,} =~ ${gpuvendoramd} ]]; then
-        if ! ([[ $amdsmicmd =~ $invalid || -z "$amdsmicmd" ]]); then
+        if [ -e $amdcmdpath ]; then
             echo $displaydevice
         fi
     fi

--- a/os-discovery-tool/gpudriver.sh
+++ b/os-discovery-tool/gpudriver.sh
@@ -5,7 +5,7 @@ lspcicmd=`which lspci`
 modinfocmd=`which modinfo`
 osvendor=$(cat /etc/*-release 2>/dev/null | grep -i ^ID= | head -n1 | awk -F"=" '{print $2}'| xargs)
 nvidiasmicmd=`which nvidia-smi 2>&1`
-amdsmicmd=`which amd-smi 2>&1`
+amdcmdpath="/opt/rocm/.info/version"
 invalid=" |'"
 
 # List of OS vendors who support nvidia drivers
@@ -70,10 +70,9 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
             continue
          fi
     elif [[ ${displaydevice,,} =~ 'amd' ]]; then
-        if ! ([[ $amdsmicmd =~ $invalid || -z "$amdsmicmd" ]]); then
-            amdgpudriver=$(${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs);
-            amdgpuversion=$(${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep -i "version" | head -n1 | awk '{print $2}' | xargs)
-	    echo "${amdgpudriver}, ${amdgpuversion}"
+        if [ -e $amdcmdpath ]; then
+            amdgpuversion=$(cat $amdcmdpath)
+	    echo "rocm",$amdgpuversion
         fi
     fi
 done


### PR DESCRIPTION
Earlier we used to track amd-smi version for amdgpu but AMD confirmed that we have to track rocm driver version for amdgpu and hence necessary changes were made.

sample output:
```
 -kv:
  key: os.driver.10.name
  value: rocm
 -kv:
  key: os.driver.10.version
  value: 6.3.2-66
 -kv:
  key: os.driver.10.description
  value: Advanced Micro Devices, Inc. [AMD/ATI] Device 0c34
```