### PR TITLE
Addressing mellanox adapter version missing issue

### DIFF
--- a/os-discovery-tool/netdriver.sh
+++ b/os-discovery-tool/netdriver.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
+
 export PATH=$PATH:/sbin:/usr/sbin
 lshwcmd=`which lshw`
 lspcicmd=`which lspci`
 for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs;
+    pcioutput=$("$lspcicmd" -v -s "$pciaddress")
+    kernel_driver=$(echo "$pcioutput" | grep "Kernel driver" | awk '{print $NF}')
+    kernel_modules=$(echo "$pcioutput" | grep "Kernel modules" | awk '{print $NF}')
+    if [ -n "$kernel_driver" ]; then
+        echo $kernel_driver
+    else
+        echo $kernel_modules
+    fi
 done
-# support for Emulex HBA Adapter
+# support for QLogic and Emulex HBA Adapter
 ${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}'| xargs;

--- a/os-discovery-tool/netversions.sh
+++ b/os-discovery-tool/netversions.sh
@@ -1,21 +1,28 @@
 #!/bin/bash
+
 export PATH=$PATH:/sbin:/usr/sbin
 lshwcmd=`which lshw`
 lspcicmd=`which lspci`
 modinfocmd=`which modinfo`
 for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    versionstring=`${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | \
-    awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | head -n1 | awk '{print $2}' | xargs`
-if [ -z "${versionstring}" ]
-    then
-        echo `${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}' | \
-    xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'`
+    pcioutput=$("$lspcicmd" -v -s "$pciaddress")
+    kernel_driver=$(echo "$pcioutput" | grep "Kernel driver" | awk '{print $NF}')
+    kernel_modules=$(echo "$pcioutput" | grep "Kernel modules" | awk '{print $NF}')
+    if [ -n "$kernel_driver" ]; then
+        kernel_info=$kernel_driver
     else
-        echo ${versionstring}
+        kernel_info=$kernel_modules
+    fi
+    version=$(${modinfocmd} $kernel_info 2>/dev/null | grep ^version: | head -n1 | awk '{print $2}' | xargs)
+    vermagic=$(${modinfocmd} $kernel_info 2>/dev/null | grep ^vermagic: | awk '{print $2}' | xargs)
+    if [ -n "${version}" ]; then
+        echo $version
+    else
+        echo $vermagic
     fi
 done
-# support for Emulex HBA Adapter
+# support for QLogic and Emulex HBA Adapter
 ${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
 do
     hbaversionstring=`${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | awk '{print $2}'`


### PR DESCRIPTION
**Issue:**
Mellanox adapter version is missing in the host-inv.yaml file.

**Root cause:**
Key name in the lspci output changed from `Kernel driver` to `Kernel modules` which caused the issue.

**e.g:**
```
[root@localhost os-discovery-tool]# lspci -v -s b4:00.0
b4:00.0 Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated ConnectX-7 network controller (rev 01)
	Subsystem: Mellanox Technologies Device 0022
	Physical Slot: 109
	Flags: bus master, fast devsel, latency 0, IRQ 255, NUMA node 1
	Memory at 233ffa000000 (64-bit, prefetchable) [size=32M]
	Memory at 233ffc800000 (64-bit, prefetchable) [size=8M]
	Expansion ROM at dd200000 [disabled] [size=1M]
	Capabilities: [60] Express Endpoint, MSI 00
	Capabilities: [48] Vital Product Data
	Capabilities: [9c] MSI-X: Enable- Count=64 Masked-
	Capabilities: [c0] Vendor Specific Information: Len=18 <?>
	Capabilities: [40] Power Management version 3
	Capabilities: [100] Advanced Error Reporting
	Capabilities: [150] Alternative Routing-ID Interpretation (ARI)
	Capabilities: [180] Single Root I/O Virtualization (SR-IOV)
	Capabilities: [1c0] Secondary PCI Express
	Capabilities: [230] Access Control Services
	Capabilities: [240] Precision Time Measurement
	Capabilities: [320] Lane Margining at the Receiver <?>
	Capabilities: [370] Physical Layer 16.0 GT/s <?>
	Capabilities: [3b0] Extended Capability ID 0x2a
	Capabilities: [420] Data Link Feature <?>
	Kernel modules: mlx5_core
```

**Fix:** if `Kernel driver` not available, then data is fetched from `Kernel modules`

**sample output:**
```
 -kv:
  key: os.driver.4.name
  value: mlx5_core
 -kv:
  key: os.driver.4.version
  value: 24.10-1.1.4
 -kv:
  key: os.driver.4.description
  value: Mellanox Technologies Device 0022
```

